### PR TITLE
Fixed a^x derivative

### DIFF
--- a/cheatsheet.typ
+++ b/cheatsheet.typ
@@ -430,7 +430,7 @@
   ][
     #text(
       fill: derivate,
-      $ a dot log(a) $,
+      $ a^x dot log(a) $,
     )
   ][
     $ a^x $


### PR DESCRIPTION
la derivata attuale di a^x è a * log(a) e dovrebbe essere a^x * log(a)